### PR TITLE
Group crops with tags

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -163,28 +163,29 @@ async function doAdd() {
 	const documents = parseOptionArray('document');
 	const params = { documents: documents };
 
+	let createdDocuments;
 	switch (model) {
 		case 'crop': {
-			await addCrops(params);
+			createdDocuments = await addCrops(params);
 			break;
 		}
 		case 'crop-relationship': {
-			await addCropRelationships(params);
+			createdDocuments = await addCropRelationships(params);
 			break;
 		}
 		case 'crop-tag': {
-			await addCropTags(params);
+			createdDocuments = await addCropTags(params);
 			break;
 		}
 		case 'user': {
-			await addUsers(params);
+			createdDocuments = await addUsers(params);
 			break;
 		}
 		default:
 		break;
 	}
 
-	console.log(documents);
+	console.log(createdDocuments.map(document => document.data));
 }
 
 /**

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -3,7 +3,32 @@
  * @memberof cli
  */
 
-const { setBaseUrl, getCropsByName, getCropGroups, getCompatibleCrops, getCrops, getCropRelationships, getUsers, addCrop, addCropRelationship, addCrops, addCropRelationships, addUsers, setCrops, setCropRelationships, setUsers, removeCrops, removeCropRelationships, removeUsers, removeAllCrops, removeAllCropRelationships } = require('../shared/api-client.js');
+const {
+	setBaseUrl,
+	getCropsByName,
+	getCropGroups,
+	getCompatibleCrops,
+	getCrops,
+	getCropRelationships,
+	getCropTags,
+	getUsers,
+	addCrop,
+	addCropRelationship,
+	addCrops,
+	addCropRelationships,
+	addCropTags,
+	addUsers,
+	setCrops,
+	setCropRelationships,
+	setCropTags,
+	setUsers,
+	removeCrops,
+	removeCropRelationships,
+	removeCropTags,
+	removeUsers,
+	removeAllCrops,
+	removeAllCropRelationships
+} = require('../shared/api-client.js');
 const practicalplants = require('../db/practicalplants.js');
 const { plants, companions } = require('../db/companions.js');
 const { PP_PORT, API_HOST } = require('../secrets.js');
@@ -113,6 +138,10 @@ async function doShow() {
 			responses = await getCropRelationships(params);
 			break;
 		}
+		case 'crop-tag': {
+			responses = await getCropTags(params);
+			break;
+		}
 		case 'user': {
 			responses = await getUsers(params);
 			break;
@@ -143,6 +172,10 @@ async function doAdd() {
 			await addCropRelationships(params);
 			break;
 		}
+		case 'crop-tag': {
+			await addCropTags(params);
+			break;
+		}
 		case 'user': {
 			await addUsers(params);
 			break;
@@ -170,6 +203,10 @@ async function doUpdate() {
 		}
 		case 'crop-relationship': {
 			await setCropRelationships(params);
+			break;
+		}
+		case 'crop-tag': {
+			await setCropTags(params);
 			break;
 		}
 		case 'user': {
@@ -204,6 +241,10 @@ async function doRemove() {
 			} else {
 				await removeAllCropRelationships();
 			}
+			break;
+		}
+		case 'crop-tag': {
+			await removeCropTags(params);
 			break;
 		}
 		case 'user': {

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -297,6 +297,7 @@ async function pushCompanions() {
 	
 	const plantNameToCrop = {};
 	crops.forEach(crop => {
+		crop.tags = [];
 		plantNameToCrop[crop.binomialName] = crop;
 	});
 	

--- a/client/components/Main.js
+++ b/client/components/Main.js
@@ -10,6 +10,7 @@ const Register = require('./register/RegisterPage');
 const Recover = require('./recover/Recover');
 const LocationsPage = require('./locations/LocationsPage');
 const AboutPage = require('./about/AboutPage');
+const CropsPage = require('./crops/CropsPage');
 const { saveLocationRequest } = require('../actions/locationActions');
 const { connect } = require('react-redux');
 
@@ -63,6 +64,7 @@ class Main extends React.Component {
 						<Route path="/recover" component={Recover} />
 						<Route path="/locations" component={LocationsPage} />
 						<Route path="/about" component={AboutPage} />
+						<Route path="/crops" component={CropsPage} />
 					</Switch>
 				</div>
 			);

--- a/client/components/crops/CropPage.js
+++ b/client/components/crops/CropPage.js
@@ -1,0 +1,64 @@
+const React = require('react');
+const TagsInput = require('react-tagsinput');
+require('react-tagsinput/react-tagsinput.css');
+const { Redirect } = require('react-router-dom');
+const { addCropTags, setCrop } = require('../../../shared/api-client.js');
+
+/**
+ *
+ */
+class CropPage extends React.Component {
+  constructor(props) {
+    super(props);
+    
+    this.state = {
+      tags: props.crop.tags.map(tag => tag.name),
+      saved: false
+    };
+  }
+  
+  onSave() {
+    const tagsToSave = this.state.tags.filter(name => this.props.tags.every(tag => (tag.name != name))).map(name => ({ name: name }));
+    
+    addCropTags({ documents: tagsToSave })
+      .then(results => {
+        this.props.crop.tags = this.state.tags.map(name => {
+          let tag;
+          
+          tag = this.props.tags.find(tag => (tag.name == name));
+          if (tag) {
+            return tag;
+          }
+          
+          return results.map(result => result.data).find(tag => (tag.name == name));
+        });
+        setCrop({ document: { tags: this.props.crop.tags.map(tag => tag._id) }, id: this.props.crop._id.toString() })
+          .then(result => {
+            this.setState({ saved: true });
+          });
+      });
+  }
+  
+  render() {
+    if (this.state.saved) {
+      return <Redirect to='/crops' />;
+    }
+    
+    return (
+      <div>
+        <h3>{ this.props.crop.binomialName }</h3>
+        <TagsInput
+          value = { this.state.tags }
+          onChange = { (tags) => { this.setState({ tags }) } }
+          />
+        <button
+          onClick = { this.onSave.bind(this) }
+          >
+          Save
+        </button>
+      </div>
+    );
+  }
+}
+
+module.exports = CropPage;

--- a/client/components/crops/CropsPage.js
+++ b/client/components/crops/CropsPage.js
@@ -1,0 +1,124 @@
+const React = require('react');
+const PropTypes = require('prop-types');
+const { connect } = require('react-redux');
+const { Switch, Route, Link } = require('react-router-dom');
+const { fetchCrops } = require('../../actions/cropActions');
+const CropPage = require('./CropPage');
+
+/**
+ * Page that lists crops
+ *
+ * @extends Component
+ */
+class CropsPage extends React.Component {
+	constructor(props) {
+		super(props);
+	}
+	
+	componentWillMount() {
+		this.props.fetchCrops();
+	}
+
+	collectTags() {
+		const tagNames = [];
+		const tags = [];
+		this.props.crops.all.forEach(crop => {
+			if (crop.tags) {
+				crop.tags.forEach(tag => {
+					if (!tagNames.includes(tag.name)) {
+						tagNames.push(tag.name);
+						tags.push(tag);
+					}
+				});
+			}
+		});
+		return tags;
+	}
+
+	renderCropsByTag(props) {
+		const listItems = this.props.crops.all.filter(crop => (crop.tags.some(tag => (tag.name == props.match.params.tag)))).map(crop => (
+			<li>
+				{ crop.commonName ? (crop.binomialName + ' (' + crop.commonName + ')') : (crop.binomialName)}
+			</li>
+		));
+		return (
+			<ul>
+				{ listItems }
+			</ul>
+		);
+	}
+
+	render() {
+		if (this.props.loading) {
+			return <p>Loading</p>;
+		}
+		
+		const listItems = this.props.crops.all.map((crop, index) => (
+			<li>
+				<Link to = { this.props.match.url + '/' + index }>
+					{ crop.commonName ? (crop.binomialName + ' (' + crop.commonName + ')') : (crop.binomialName)}
+				</Link>
+			</li>
+		));
+		const tags = this.collectTags().map(tag => (
+			<Link to = { this.props.match.url + '/tags/' + tag.name }>
+				<button>{ tag.name }</button>
+			</Link>
+		));
+		
+		return (
+			<div>
+				<Switch>
+					<Route
+						exact path = { this.props.match.url }
+						render = {
+							() => (
+								<div>
+									<div>
+										{ tags }
+									</div>
+									<ul>
+										{ listItems }
+									</ul>
+								</div>
+							)
+						}
+						/>
+					<Route
+						path = { this.props.match.url + '/tags/:tag' }
+						render = { this.renderCropsByTag.bind(this) }
+						/>
+					<Route
+						path = { this.props.match.url + '/:index' }
+						render = {
+							(props) => (
+								<CropPage
+									crop = { this.props.crops.all[parseInt(props.match.params.index, 10)] }
+									tags = { this.collectTags() }
+									/>
+							)
+						}
+						/>
+				</Switch>
+			</div>
+		);
+	}
+};
+
+CropsPage.propTypes = {
+	crops : PropTypes.object.isRequired,
+	loading : PropTypes.bool.isRequired,
+	error : PropTypes.bool.isRequired,
+}
+
+const mapDispatchToProps = (dispatch) => ({
+	fetchCrops: () => dispatch(fetchCrops())
+});
+
+const mapStateToProps = (state) => ({
+	crops: state.crops,
+	loading: state.crops.loading,
+	error: state.crops.error,
+});
+
+module.exports = connect (mapStateToProps, mapDispatchToProps)(CropsPage);

--- a/client/components/header/Header.js
+++ b/client/components/header/Header.js
@@ -28,6 +28,9 @@ class Header extends React.Component {
 						<LinkContainer exact to="/">
 							<NavItem eventKey={1.0}>Home</NavItem>
 						</LinkContainer>
+						<LinkContainer exact to="/crops">
+							<NavItem eventKey={1.0}>Crops</NavItem>
+						</LinkContainer>
 						<LinkContainer exact to="/about">
 							<NavItem eventKey={1.0}>About</NavItem>
 						</LinkContainer>

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,187 +20,202 @@
       }
     },
     "@webassemblyjs/ast": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.11.tgz",
-      "integrity": "sha512-ZEzy4vjvTzScC+SH8RBssQUawpaInUdMTYwYYLh54/s8TuT0gBLuyUnppKsVyZEi876VmmStKsUs28UxPgdvrA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.2.tgz",
+      "integrity": "sha512-5LLqqVsXZAhAJN0S7fTi11jwMJOjfR8290V0V7BWKgmZ36VVE6ZGuH4BN3eLt7LvNMIgyuYwyrPwiz6f3SGlBQ==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/helper-module-context": "1.7.11",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
-        "@webassemblyjs/wast-parser": "1.7.11"
+        "@webassemblyjs/helper-module-context": "1.8.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.2",
+        "@webassemblyjs/wast-parser": "1.8.2"
       }
     },
     "@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.11.tgz",
-      "integrity": "sha512-zY8dSNyYcgzNRNT666/zOoAyImshm3ycKdoLsyDw/Bwo6+/uktb7p4xyApuef1dwEBo/U/SYQzbGBvV+nru2Xg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.2.tgz",
+      "integrity": "sha512-5WIj+pSzbs8ao7NM31xFcGeOSnXgpCikmCFRYkXygVDqVaXTq/Hr9roqarUVMNfAegNc61oKEhe3pi+HUCXJEw==",
       "dev": true
     },
     "@webassemblyjs/helper-api-error": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.11.tgz",
-      "integrity": "sha512-7r1qXLmiglC+wPNkGuXCvkmalyEstKVwcueZRP2GNC2PAvxbLYwLLPr14rcdJaE4UtHxQKfFkuDFuv91ipqvXg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.2.tgz",
+      "integrity": "sha512-TJBDJPXO9DSC4qf5FZT0VFlTdJSm4DKxzcoyWwVike1aQQQEbCk167MJxYLi0SuHeOtULLtDDSZL7yDL3XXMKA==",
       "dev": true
     },
     "@webassemblyjs/helper-buffer": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.11.tgz",
-      "integrity": "sha512-MynuervdylPPh3ix+mKZloTcL06P8tenNH3sx6s0qE8SLR6DdwnfgA7Hc9NSYeob2jrW5Vql6GVlsQzKQCa13w==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.2.tgz",
+      "integrity": "sha512-6fTynU6b0bC+yBH7+M6/BBRZId4F1fIuX00G1ZX45EAQOrB8p4TK5bccAEPG2vuyvnd4tgB1/4cYXq5GpszMGA==",
       "dev": true
     },
     "@webassemblyjs/helper-code-frame": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.11.tgz",
-      "integrity": "sha512-T8ESC9KMXFTXA5urJcyor5cn6qWeZ4/zLPyWeEXZ03hj/x9weSokGNkVCdnhSabKGYWxElSdgJ+sFa9G/RdHNw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.2.tgz",
+      "integrity": "sha512-5beYTZS4Wsscu8ys2cLZ0SiToEe1wNitzrV/jCr02wGPOcpPHf0ERImR6iBGe/LX0O2cV9Pgi78hFp5WfNKeAg==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/wast-printer": "1.7.11"
+        "@webassemblyjs/wast-printer": "1.8.2"
       }
     },
     "@webassemblyjs/helper-fsm": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.11.tgz",
-      "integrity": "sha512-nsAQWNP1+8Z6tkzdYlXT0kxfa2Z1tRTARd8wYnc/e3Zv3VydVVnaeePgqUzFrpkGUyhUUxOl5ML7f1NuT+gC0A==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.2.tgz",
+      "integrity": "sha512-7xRO1lFNj1fGm+ik73n8TuWXKeAqTuqeApqnxWnW+nI2lPyj4awrt+n1XkQr8OwmVK7mFJSRuTZc568qtgOyzQ==",
       "dev": true
     },
     "@webassemblyjs/helper-module-context": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.11.tgz",
-      "integrity": "sha512-JxfD5DX8Ygq4PvXDucq0M+sbUFA7BJAv/GGl9ITovqE+idGX+J3QSzJYz+LwQmL7fC3Rs+utvWoJxDb6pmC0qg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.2.tgz",
+      "integrity": "sha512-EBr+n9M2F7PQ02s0f87KnSPva0KlT2S4IGDP+7aYqt2FCaMZzCtXcVahGSGg3ESZBSD0gzFU4486zD7SUsSD0Q==",
       "dev": true
     },
     "@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.11.tgz",
-      "integrity": "sha512-cMXeVS9rhoXsI9LLL4tJxBgVD/KMOKXuFqYb5oCJ/opScWpkCMEz9EJtkonaNcnLv2R3K5jIeS4TRj/drde1JQ==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.2.tgz",
+      "integrity": "sha512-gS0trUUPYevbs5Rsv9E+VbzDuZ9KB4Tu/QymTfHtnSDpX4wxhs9u9/y/KiH84r0Z4xvm8/pqWnGvM77oxSPHYw==",
       "dev": true
     },
     "@webassemblyjs/helper-wasm-section": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.11.tgz",
-      "integrity": "sha512-8ZRY5iZbZdtNFE5UFunB8mmBEAbSI3guwbrsCl4fWdfRiAcvqQpeqd5KHhSWLL5wuxo53zcaGZDBU64qgn4I4Q==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.2.tgz",
+      "integrity": "sha512-HLHOR6/Vc+f5UziOUNQ3f5YedCMCuU46BdMEhjQBQwlOWqVAxgwqUn/KJkuhMvvjQ2FkASaDup8ohZrjyCKDKg==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.11",
-        "@webassemblyjs/helper-buffer": "1.7.11",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
-        "@webassemblyjs/wasm-gen": "1.7.11"
+        "@webassemblyjs/ast": "1.8.2",
+        "@webassemblyjs/helper-buffer": "1.8.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.2",
+        "@webassemblyjs/wasm-gen": "1.8.2"
       }
     },
     "@webassemblyjs/ieee754": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.7.11.tgz",
-      "integrity": "sha512-Mmqx/cS68K1tSrvRLtaV/Lp3NZWzXtOHUW2IvDvl2sihAwJh4ACE0eL6A8FvMyDG9abes3saB6dMimLOs+HMoQ==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.2.tgz",
+      "integrity": "sha512-v9RtqGJ+z8UweiRh47DheXVtV0d/o9sQfXzAX1/1n/nw5G85yEQJdHcmwiRdu+SXmqlZQeymsnmve2oianzW4g==",
       "dev": true,
       "requires": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "@webassemblyjs/leb128": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.7.11.tgz",
-      "integrity": "sha512-vuGmgZjjp3zjcerQg+JA+tGOncOnJLWVkt8Aze5eWQLwTQGNgVLcyOTqgSCxWTR4J42ijHbBxnuRaL1Rv7XMdw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.2.tgz",
+      "integrity": "sha512-41zX+6xpo6G2bkq3mdr+K5nXx5OOL6V979ucbLyq1ra5dFI3ReLiw6+HOCF5ih0t5HMQVIQBhInZIdxqcpc/Qg==",
       "dev": true,
       "requires": {
-        "@xtuc/long": "4.2.1"
+        "long": "git://github.com/dcodeIO/long.js.git#8181a6b50a2a230f0b2a1e4c4093f9b9d19c8b69"
+      },
+      "dependencies": {
+        "long": {
+          "version": "git://github.com/dcodeIO/long.js.git#8181a6b50a2a230f0b2a1e4c4093f9b9d19c8b69",
+          "from": "git://github.com/dcodeIO/long.js.git#8181a6b50a2a230f0b2a1e4c4093f9b9d19c8b69",
+          "dev": true
+        }
       }
     },
     "@webassemblyjs/utf8": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.7.11.tgz",
-      "integrity": "sha512-C6GFkc7aErQIAH+BMrIdVSmW+6HSe20wg57HEC1uqJP8E/xpMjXqQUxkQw07MhNDSDcGpxI9G5JSNOQCqJk4sA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.2.tgz",
+      "integrity": "sha512-fP2Q4igo9/R82xeVra+zIQOjnmknSiAhykg//fz7c1UjghzoutQtldcbKOaL0+0j31RRFMDHgrUL+12RQExOYg==",
       "dev": true
     },
     "@webassemblyjs/wasm-edit": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.11.tgz",
-      "integrity": "sha512-FUd97guNGsCZQgeTPKdgxJhBXkUbMTY6hFPf2Y4OedXd48H97J+sOY2Ltaq6WGVpIH8o/TGOVNiVz/SbpEMJGg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.2.tgz",
+      "integrity": "sha512-rM1sgdLQrXQs4ZapglK86mW8QMml0FJ+jwZ5961sEmHISTkJRvheILuzA9jcKy5vwhWgkPf/nIhO2I6A9rkGww==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.11",
-        "@webassemblyjs/helper-buffer": "1.7.11",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
-        "@webassemblyjs/helper-wasm-section": "1.7.11",
-        "@webassemblyjs/wasm-gen": "1.7.11",
-        "@webassemblyjs/wasm-opt": "1.7.11",
-        "@webassemblyjs/wasm-parser": "1.7.11",
-        "@webassemblyjs/wast-printer": "1.7.11"
+        "@webassemblyjs/ast": "1.8.2",
+        "@webassemblyjs/helper-buffer": "1.8.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.2",
+        "@webassemblyjs/helper-wasm-section": "1.8.2",
+        "@webassemblyjs/wasm-gen": "1.8.2",
+        "@webassemblyjs/wasm-opt": "1.8.2",
+        "@webassemblyjs/wasm-parser": "1.8.2",
+        "@webassemblyjs/wast-printer": "1.8.2"
       }
     },
     "@webassemblyjs/wasm-gen": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.11.tgz",
-      "integrity": "sha512-U/KDYp7fgAZX5KPfq4NOupK/BmhDc5Kjy2GIqstMhvvdJRcER/kUsMThpWeRP8BMn4LXaKhSTggIJPOeYHwISA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.2.tgz",
+      "integrity": "sha512-WTBesrMydDwJbbB48OZGcMq6zDsT6CJd1UalvGuXtHJLargazOron+JBdmt8Nnd+Z2s3TPfCPP54EpQBsDVR7Q==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.11",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
-        "@webassemblyjs/ieee754": "1.7.11",
-        "@webassemblyjs/leb128": "1.7.11",
-        "@webassemblyjs/utf8": "1.7.11"
+        "@webassemblyjs/ast": "1.8.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.2",
+        "@webassemblyjs/ieee754": "1.8.2",
+        "@webassemblyjs/leb128": "1.8.2",
+        "@webassemblyjs/utf8": "1.8.2"
       }
     },
     "@webassemblyjs/wasm-opt": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.11.tgz",
-      "integrity": "sha512-XynkOwQyiRidh0GLua7SkeHvAPXQV/RxsUeERILmAInZegApOUAIJfRuPYe2F7RcjOC9tW3Cb9juPvAC/sCqvg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.2.tgz",
+      "integrity": "sha512-tzXn0xNQNyoUBr1+O1rwYXZd2bcUdXSOUTu0fLAIPl01dcTY6hjIi2B2DXYqk9OVQRnjPyX2Ew6rkeCTxfaYaQ==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.11",
-        "@webassemblyjs/helper-buffer": "1.7.11",
-        "@webassemblyjs/wasm-gen": "1.7.11",
-        "@webassemblyjs/wasm-parser": "1.7.11"
+        "@webassemblyjs/ast": "1.8.2",
+        "@webassemblyjs/helper-buffer": "1.8.2",
+        "@webassemblyjs/wasm-gen": "1.8.2",
+        "@webassemblyjs/wasm-parser": "1.8.2"
       }
     },
     "@webassemblyjs/wasm-parser": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.11.tgz",
-      "integrity": "sha512-6lmXRTrrZjYD8Ng8xRyvyXQJYUQKYSXhJqXOBLw24rdiXsHAOlvw5PhesjdcaMadU/pyPQOJ5dHreMjBxwnQKg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.2.tgz",
+      "integrity": "sha512-uc6nVjvUjZzHa8fSl0ko684puuw0ujfCYn19v5tTu0DQ7tXx9jlZXzYw0aW7fmROxyez7BcbJloYLmXg723vVQ==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.11",
-        "@webassemblyjs/helper-api-error": "1.7.11",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
-        "@webassemblyjs/ieee754": "1.7.11",
-        "@webassemblyjs/leb128": "1.7.11",
-        "@webassemblyjs/utf8": "1.7.11"
+        "@webassemblyjs/ast": "1.8.2",
+        "@webassemblyjs/helper-api-error": "1.8.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.2",
+        "@webassemblyjs/ieee754": "1.8.2",
+        "@webassemblyjs/leb128": "1.8.2",
+        "@webassemblyjs/utf8": "1.8.2"
       }
     },
     "@webassemblyjs/wast-parser": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.7.11.tgz",
-      "integrity": "sha512-lEyVCg2np15tS+dm7+JJTNhNWq9yTZvi3qEhAIIOaofcYlUp0UR5/tVqOwa/gXYr3gjwSZqw+/lS9dscyLelbQ==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.2.tgz",
+      "integrity": "sha512-idk8cCqM+T6/iIxoQCOz85vKvWhyHghJbICob/H1AN8byN1O6a2Jxk+g1ZJA7sZDc6/q8pYV6dVkHKgm8y1oUA==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.11",
-        "@webassemblyjs/floating-point-hex-parser": "1.7.11",
-        "@webassemblyjs/helper-api-error": "1.7.11",
-        "@webassemblyjs/helper-code-frame": "1.7.11",
-        "@webassemblyjs/helper-fsm": "1.7.11",
-        "@xtuc/long": "4.2.1"
+        "@webassemblyjs/ast": "1.8.2",
+        "@webassemblyjs/floating-point-hex-parser": "1.8.2",
+        "@webassemblyjs/helper-api-error": "1.8.2",
+        "@webassemblyjs/helper-code-frame": "1.8.2",
+        "@webassemblyjs/helper-fsm": "1.8.2",
+        "long": "git://github.com/dcodeIO/long.js.git#8181a6b50a2a230f0b2a1e4c4093f9b9d19c8b69"
+      },
+      "dependencies": {
+        "long": {
+          "version": "git://github.com/dcodeIO/long.js.git#8181a6b50a2a230f0b2a1e4c4093f9b9d19c8b69",
+          "from": "git://github.com/dcodeIO/long.js.git#8181a6b50a2a230f0b2a1e4c4093f9b9d19c8b69",
+          "dev": true
+        }
       }
     },
     "@webassemblyjs/wast-printer": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.7.11.tgz",
-      "integrity": "sha512-m5vkAsuJ32QpkdkDOUPGSltrg8Cuk3KBx4YrmAGQwCZPRdUHXxG4phIOuuycLemHFr74sWL9Wthqss4fzdzSwg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.2.tgz",
+      "integrity": "sha512-TENFBgf5bKKfs2LbW8fd/0xvamccbEHoR83lQlEP7Qi0nkpXAP77VpvIITy0J+UZAa/Y3j6K6MPw1tNMbdjf4A==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.11",
-        "@webassemblyjs/wast-parser": "1.7.11",
-        "@xtuc/long": "4.2.1"
+        "@webassemblyjs/ast": "1.8.2",
+        "@webassemblyjs/wast-parser": "1.8.2",
+        "long": "git://github.com/dcodeIO/long.js.git#8181a6b50a2a230f0b2a1e4c4093f9b9d19c8b69"
+      },
+      "dependencies": {
+        "long": {
+          "version": "git://github.com/dcodeIO/long.js.git#8181a6b50a2a230f0b2a1e4c4093f9b9d19c8b69",
+          "from": "git://github.com/dcodeIO/long.js.git#8181a6b50a2a230f0b2a1e4c4093f9b9d19c8b69",
+          "dev": true
+        }
       }
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "dev": true
-    },
-    "@xtuc/long": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.1.tgz",
-      "integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==",
       "dev": true
     },
     "abbrev": {
@@ -663,6 +678,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -809,9 +830,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.6.4",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.4.tgz",
-          "integrity": "sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A==",
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
           "dev": true
         },
         "regenerator-runtime": {
@@ -861,9 +882,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.6.4",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.4.tgz",
-          "integrity": "sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A==",
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
           "dev": true
         }
       }
@@ -878,9 +899,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.6.4",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.4.tgz",
-          "integrity": "sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A=="
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
         }
       }
     },
@@ -922,6 +943,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -1517,6 +1544,11 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -1709,9 +1741,9 @@
       }
     },
     "bson": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
-      "integrity": "sha512-IQX9/h7WdMBIW/q/++tGd+emQr0XMdeZ6icnT/74Xk9fnabWn+gZgpE+9V+gujL3hhJOoNrnDVY7tWdzc7NUTg=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.0.tgz",
+      "integrity": "sha512-9Aeai9TacfNtWXOYarkFJRW2CWo+dRon+fuLZYJmvLV3+MiUp0bEI6IAZfXEIg7/Pl/7IWlLaDnhzTsD81etQA=="
     },
     "buffer": {
       "version": "4.9.1",
@@ -2434,11 +2466,11 @@
       "dev": true
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
     "decamelize": {
@@ -2622,21 +2654,13 @@
       }
     },
     "dom-serializer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
       "dev": true,
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
-      },
-      "dependencies": {
-        "domelementtype": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-          "dev": true
-        }
+        "domelementtype": "^1.3.0",
+        "entities": "^1.1.1"
       }
     },
     "domain-browser": {
@@ -2974,6 +2998,12 @@
             "ms": "2.0.0"
           }
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
         "user-home": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
@@ -3009,6 +3039,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -3030,6 +3066,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -3089,6 +3131,12 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
       }
@@ -3329,6 +3377,11 @@
             "ms": "2.0.0"
           }
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
         "statuses": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -3486,6 +3539,11 @@
             "ms": "2.0.0"
           }
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
         "statuses": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -3536,11 +3594,11 @@
       }
     },
     "follow-redirects": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
-      "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
+      "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
       "requires": {
-        "debug": "=3.1.0"
+        "debug": "^3.2.6"
       }
     },
     "for-in": {
@@ -3676,14 +3734,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3698,20 +3754,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3828,8 +3881,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3841,7 +3893,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3856,7 +3907,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3864,14 +3914,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3890,7 +3938,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3971,8 +4018,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3984,7 +4030,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4106,7 +4151,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4574,17 +4618,17 @@
       "dev": true
     },
     "htmlparser2": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
-      "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
       "dev": true,
       "requires": {
-        "domelementtype": "^1.3.0",
+        "domelementtype": "^1.3.1",
         "domhandler": "^2.3.0",
         "domutils": "^1.5.1",
         "entities": "^1.1.1",
         "inherits": "^2.0.1",
-        "readable-stream": "^3.0.6"
+        "readable-stream": "^3.1.1"
       },
       "dependencies": {
         "readable-stream": {
@@ -5265,13 +5309,6 @@
         "lodash.isstring": "^4.0.1",
         "lodash.once": "^4.0.0",
         "ms": "^2.1.1"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        }
       }
     },
     "jsprim": {
@@ -5317,9 +5354,9 @@
       "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
     },
     "kareem": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.2.1.tgz",
-      "integrity": "sha512-xpDFy8OxkFM+vK6pXy6JmH92ibeEFUuDWzas5M9L7MzVmHW3jzwAHxodCPV/BYkf4A31bVDLyonrMfp9RXb/oA=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.0.tgz",
+      "integrity": "sha512-6hHxsp9e6zQU8nXsP+02HGWXwTkOEw6IROhF2ZA28cYbUk4eJ6QbtZvdqZOdD9YPKghG3apk5eOCvs+tLl3lRg=="
     },
     "keycode": {
       "version": "2.2.0",
@@ -5792,16 +5829,16 @@
       "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
     },
     "mime-db": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
     },
     "mime-types": {
-      "version": "2.1.21",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+      "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
       "requires": {
-        "mime-db": "~1.37.0"
+        "mime-db": "~1.38.0"
       }
     },
     "minimalistic-assert": {
@@ -5922,6 +5959,15 @@
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -5935,6 +5981,12 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
@@ -5954,47 +6006,39 @@
       "dev": true
     },
     "mongodb": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.6.tgz",
-      "integrity": "sha512-E5QJuXQoMlT7KyCYqNNMfAkhfQD79AT4F8Xd+6x37OX+8BL17GyXyWvfm6wuyx4wnzCCPoCSLeMeUN2S7dU9yw==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.13.tgz",
+      "integrity": "sha512-sz2dhvBZQWf3LRNDhbd30KHVzdjZx9IKC0L+kSZ/gzYquCF5zPOgGqRz6sSCqYZtKP2ekB4nfLxhGtzGHnIKxA==",
       "requires": {
-        "mongodb-core": "3.1.5",
+        "mongodb-core": "3.1.11",
         "safe-buffer": "^5.1.2"
       }
     },
     "mongodb-core": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.5.tgz",
-      "integrity": "sha512-emT/tM4ZBinqd6RZok+EzDdtN4LjYJIckv71qQVOEFmvXgT5cperZegVmTgox/1cx4XQu6LJ5ZuIwipP/eKdQg==",
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.11.tgz",
+      "integrity": "sha512-rD2US2s5qk/ckbiiGFHeu+yKYDXdJ1G87F6CG3YdaZpzdOm5zpoAZd/EKbPmFO6cQZ+XVXBXBJ660sSI0gc6qg==",
       "requires": {
         "bson": "^1.1.0",
         "require_optional": "^1.0.1",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
-      },
-      "dependencies": {
-        "bson": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.0.tgz",
-          "integrity": "sha512-9Aeai9TacfNtWXOYarkFJRW2CWo+dRon+fuLZYJmvLV3+MiUp0bEI6IAZfXEIg7/Pl/7IWlLaDnhzTsD81etQA=="
-        }
       }
     },
     "mongoose": {
-      "version": "5.2.17",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.2.17.tgz",
-      "integrity": "sha512-AYmf+QYMUM3POzPen/tzuN9spJASHIuV5FUb1HNJurEAtKXL671zLXC60GPIMDVDZSvyGfGjbr4TI5Hy4UkVgw==",
+      "version": "5.4.13",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.4.13.tgz",
+      "integrity": "sha512-4dgmFbtNECbW3ZMS6ha2pebinUzZo789scdccdyyajbmaunBPqZJqp6eO6pThIqDsgSOkRi4IrzkZm8kmhtZMA==",
       "requires": {
         "async": "2.6.1",
-        "bson": "~1.0.5",
-        "kareem": "2.2.1",
-        "lodash.get": "4.4.2",
-        "mongodb": "3.1.6",
-        "mongodb-core": "3.1.5",
+        "bson": "~1.1.0",
+        "kareem": "2.3.0",
+        "mongodb": "3.1.13",
+        "mongodb-core": "3.1.11",
         "mongoose-legacy-pluralize": "1.0.2",
         "mpath": "0.5.1",
         "mquery": "3.2.0",
-        "ms": "2.0.0",
+        "ms": "2.1.1",
         "regexp-clone": "0.0.1",
         "safe-buffer": "5.1.2",
         "sliced": "1.0.1"
@@ -6049,12 +6093,27 @@
         "regexp-clone": "0.0.1",
         "safe-buffer": "5.1.2",
         "sliced": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "mute-stream": {
       "version": "0.0.5",
@@ -6346,9 +6405,9 @@
           }
         },
         "chokidar": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.0.tgz",
-          "integrity": "sha512-5t6G2SH8eO6lCvYOoUpaRnF5Qfd//gd7qJAkwRUw9qlGVkiQ13uwQngqbWWaurOsaAm9+kUGbITADxt6H0XFNQ==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.1.tgz",
+          "integrity": "sha512-gfw3p2oQV2wEt+8VuMlNsPjCxDxvvgnm/kz+uATu805mWVF8IJN7uz9DN7iBz+RMJISmiVbCOBFs9qBGMjtPfQ==",
           "dev": true,
           "requires": {
             "anymatch": "^2.0.0",
@@ -6643,6 +6702,12 @@
             "to-regex": "^3.0.2"
           }
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
         "normalize-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -6751,9 +6816,9 @@
       }
     },
     "object-keys": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
+      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
       "dev": true
     },
     "object-visit": {
@@ -6958,9 +7023,9 @@
       }
     },
     "parse-asn1": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.3.tgz",
-      "integrity": "sha512-VrPoetlz7B/FqjBLD2f5wBVZvsZVLnRUrxVLfRYhGXCODa/NWE4p3Wp+6+aV3ZPL3KM7/OZmxDIwwijD7yuucg==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
+      "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
       "dev": true,
       "requires": {
         "asn1.js": "^4.0.0",
@@ -7292,12 +7357,13 @@
       "dev": true
     },
     "prop-types": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
       }
     },
     "prop-types-extra": {
@@ -7599,9 +7665,9 @@
       }
     },
     "react-is": {
-      "version": "16.8.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.1.tgz",
-      "integrity": "sha512-ioMCzVDWvCvKD8eeT+iukyWrBGrA3DiFYkXfBsVYIRdaREZuBjENG+KjrikavCLasozqRWTwFUagU/O4vPpRMA=="
+      "version": "16.8.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.2.tgz",
+      "integrity": "sha512-D+NxhSR2HUCjYky1q1DwpNUD44cDpUXzSmmFyC3ug1bClcU/iDNy0YNn1iwme28fn+NFhpA13IndOd42CrFb+Q=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -7706,6 +7772,11 @@
           }
         }
       }
+    },
+    "react-tagsinput": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/react-tagsinput/-/react-tagsinput-3.19.0.tgz",
+      "integrity": "sha512-ni+/qnZrYrvLg83LtTFHErKy1KQHL0fi0Y6C5jgC1dNUePE9cS/OlQ4XH6JRSjv9GGoeVE0R/ujSBaS1uzCRYQ=="
     },
     "react-transition-group": {
       "version": "2.5.3",
@@ -8055,6 +8126,12 @@
             "snapdragon": "^0.8.1",
             "to-regex": "^3.0.2"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -8634,6 +8711,11 @@
             "ms": "2.0.0"
           }
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
         "statuses": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -8822,6 +8904,12 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -9680,6 +9768,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -10102,9 +10196,9 @@
           }
         },
         "chokidar": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.0.tgz",
-          "integrity": "sha512-5t6G2SH8eO6lCvYOoUpaRnF5Qfd//gd7qJAkwRUw9qlGVkiQ13uwQngqbWWaurOsaAm9+kUGbITADxt6H0XFNQ==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.1.tgz",
+          "integrity": "sha512-gfw3p2oQV2wEt+8VuMlNsPjCxDxvvgnm/kz+uATu805mWVF8IJN7uz9DN7iBz+RMJISmiVbCOBFs9qBGMjtPfQ==",
           "dev": true,
           "requires": {
             "anymatch": "^2.0.0",
@@ -10399,6 +10493,12 @@
             "to-regex": "^3.0.2"
           }
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
         "normalize-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -10408,15 +10508,15 @@
       }
     },
     "webpack": {
-      "version": "4.29.3",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.29.3.tgz",
-      "integrity": "sha512-xPJvFeB+8tUflXFq+OgdpiSnsCD5EANyv56co5q8q8+YtEasn5Sj3kzY44mta+csCIEB0vneSxnuaHkOL2h94A==",
+      "version": "4.29.4",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.29.4.tgz",
+      "integrity": "sha512-Uu/QgPFZG+w+5wjWIFBgIy+g9vOF3QiLmT2Bl783MQSLjRF/K+GMv2TH3TVNFyPQVEHY8rVnPoQtcqrnqK2H7Q==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.11",
-        "@webassemblyjs/helper-module-context": "1.7.11",
-        "@webassemblyjs/wasm-edit": "1.7.11",
-        "@webassemblyjs/wasm-parser": "1.7.11",
+        "@webassemblyjs/ast": "1.8.2",
+        "@webassemblyjs/helper-module-context": "1.8.2",
+        "@webassemblyjs/wasm-edit": "1.8.2",
+        "@webassemblyjs/wasm-parser": "1.8.2",
         "acorn": "^6.0.5",
         "acorn-dynamic-import": "^4.0.0",
         "ajv": "^6.1.0",
@@ -10745,6 +10845,12 @@
             "snapdragon": "^0.8.1",
             "to-regex": "^3.0.2"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "schema-utils": {
           "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.11",
     "lodash.isempty": "^4.4.0",
-    "mongoose": "5.2.17",
+    "mongoose": "5.4.13",
     "mongoose-unique-validator": "^2.0.2",
     "mysql2": "^1.4.2",
     "prop-types": "^15.5.10",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "react-redux": "^5.0.5",
     "react-router-bootstrap": "^0.24.2",
     "react-router-dom": "^4.1.1",
+    "react-tagsinput": "^3.19.0",
     "redux": "^3.7.1",
     "redux-logger": "^3.0.6",
     "redux-persist": "^4.8.2",

--- a/server/middleware.js
+++ b/server/middleware.js
@@ -88,9 +88,15 @@ async function endSessionAndTransaction(session) {
 /**
  * Start session and transaction.
  *
+ * @param {Model} model Mongoose collection to be created
  * @return {Object} Session object
  */
-async function startSessionAndTransaction() {
+async function startSessionAndTransaction(model) {
+	if (model) {
+		// Initialize collection.
+		await model.createCollection();
+	}
+	
 	const session = await mongoose.startSession();
 	startTransaction(session);
 	return session;
@@ -147,7 +153,7 @@ async function documentGet(req, res, next, model) {
 	try {
 		const id = req.params.id;
 
-		const session = await startSessionAndTransaction();
+		const session = await startSessionAndTransaction(model);
 		let document;
 		if (authorizedModels.includes(model)) {
 			const authenticatedUser = await getAuthenticatedUser(req, next, session);
@@ -184,8 +190,8 @@ async function documentPut(req, res, next, model) {
 	try {
 		const id = req.params.id;
 		const update = req.body;
-
-		const session = await startSessionAndTransaction();
+		
+		const session = await startSessionAndTransaction(model);
 		let document;
 		if (authorizedModels.includes(model)) {
 			const authenticatedUser = await getAuthenticatedUser(req, next, session);
@@ -221,7 +227,7 @@ async function documentPut(req, res, next, model) {
  */
 async function documentPost(req, res, next, model) {
 	try {
-		const session = await startSessionAndTransaction();
+		const session = await startSessionAndTransaction(model);
 		let document;
 		if (authorizedModels.includes(model)) {
 			const authenticatedUser = await getAuthenticatedUser(req, next, session);
@@ -254,7 +260,7 @@ async function documentDelete(req, res, next, model) {
 	try {
 		const id = req.params.id;
 
-		const session = await startSessionAndTransaction();
+		const session = await startSessionAndTransaction(model);
 		if (authorizedModels.includes(model)) {
 			const authenticatedUser = await getAuthenticatedUser(req, next, session);
 			await processor.deleteAuthorizedDocument(session, authenticatedUser, model, id);
@@ -282,7 +288,7 @@ async function documentDelete(req, res, next, model) {
  */
 async function getAllCropRelationships(req, res, next) {
 	try {
-		const session = await startSessionAndTransaction();
+		const session = await startSessionAndTransaction(null);
 		const relationships = await processor.getAllDocuments(session, CropRelationship);
 		await endSessionAndTransaction(session);
 		
@@ -314,7 +320,7 @@ async function getCropsByName(req, res, next) {
 			0
 		);
 
-		const session = await startSessionAndTransaction();
+		const session = await startSessionAndTransaction(null);
 		const crops = await processor.getCropsByName(session, name, index, length);
 		await endSessionAndTransaction(session);
 
@@ -338,7 +344,7 @@ async function getCropsByName(req, res, next) {
  */
 async function getCropGroups(req, res, next) {
 	try {
-		const session = await startSessionAndTransaction();
+		const session = await startSessionAndTransaction(null);
 		const groups = await processor.getCropGroups(session, req.body.cropIds);
 		await endSessionAndTransaction(session);
 
@@ -362,7 +368,7 @@ async function getCropGroups(req, res, next) {
  */
 async function getCompatibleCrops(req, res, next) {
 	try {
-		const session = await startSessionAndTransaction();
+		const session = await startSessionAndTransaction(null);
 		const crops = await processor.getCompatibleCrops(session, req.body.cropIds);
 		await endSessionAndTransaction(session);
 
@@ -384,7 +390,7 @@ async function getCompatibleCrops(req, res, next) {
  */
 async function getLocations(req, res, next) {
 	try {
-		const session = await startSessionAndTransaction();
+		const session = await startSessionAndTransaction(null);
 		const user = await getAuthenticatedUser(req, next, session);
 		await endSessionAndTransaction(session);
 		
@@ -404,7 +410,7 @@ async function getLocations(req, res, next) {
  */
 async function login(req, res, next) {
 	try {
-		const session = await startSessionAndTransaction();
+		const session = await startSessionAndTransaction(null);
 		const result = await processor.login(session, req.body);
 		await endSessionAndTransaction(session);
 		res.json(result);

--- a/server/models/crop-tag.js
+++ b/server/models/crop-tag.js
@@ -1,0 +1,17 @@
+const mongoose = require('mongoose');
+
+/**
+ * Tag represents a group of crops that share a common property.
+ *
+ * TODO Add field 'description' that describes the common property.
+ */
+const cropTagSchema = new mongoose.Schema({
+  name: {
+    type: String,
+    required: true
+  },
+});
+
+const CropTag = mongoose.model('CropTag', cropTagSchema);
+
+module.exports = CropTag;

--- a/server/models/crop.js
+++ b/server/models/crop.js
@@ -1,6 +1,8 @@
 const mongoose = require('mongoose');
 const practicalplants = require('../../db/practicalplants.js');
 
+const ObjectId = mongoose.Schema.Types.ObjectId;
+
 /**
  * A Crop Model representing a plant or mushrooms species
  * TODO: write documentation for params see practicalplants.org
@@ -49,6 +51,10 @@ const cropSchema = new mongoose.Schema({
 	commonName: {
 		type: String
 	},
+	tags: [{
+		type: ObjectId,
+		ref: 'CropTag'
+	}],
 	cuttingType: [{
 		type: String,
 		enum: practicalplants.PP_CUTTING_TYPE_VALUES

--- a/server/processor.js
+++ b/server/processor.js
@@ -81,7 +81,16 @@ function authorize(currentUser, documents) {
  */
 async function getDocuments(session, model, ids) {
 	validate(ids);
-	const path = model == CropRelationship ? 'crop0 crop1' : '';
+	
+	let path;
+	if (model == CropRelationship) {
+		path = 'crop0 crop1';
+	} else if (model == Crop) {
+		path = 'tags';
+	} else {
+		path = '';
+	}
+	
 	const documents = await model.find({ _id: { $in: ids } }).session(session).populate(path).exec();
 
 	const foundIds = documents.map(document => document._id.toString());
@@ -494,7 +503,7 @@ function escapeRegEx(text) {
  * @param {Number} length
  */
 async function getCropsByName(session, regex, index, length) {
-	const crops = await Crop.find().session(session).byName(escapeRegEx(regex)).exec();
+	const crops = await Crop.find().session(session).byName(escapeRegEx(regex)).populate('tags').exec();
 	return length === 0
 		? crops.slice(index)
 		: crops.slice(index, index + length);

--- a/server/server.js
+++ b/server/server.js
@@ -23,6 +23,7 @@ const {
 } = require('./middleware');
 const Crop = require('./models/crop');
 const CropRelationship = require('./models/crop-relationship');
+const CropTag = require('./models/crop-tag');
 const Location = require('./models/location');
 const User = require('./models/user');
 const {
@@ -89,6 +90,7 @@ function buildApiRouter() {
 	 */
 	router.use('/crops', buildDocumentApiRouter(Crop));
 	router.use('/crop-relationships', buildDocumentApiRouter(CropRelationship));
+	router.use('/crop-tags', buildDocumentApiRouter(CropTag));
 	router.use('/users', buildDocumentApiRouter(User));
 	router.use('/locations', buildDocumentApiRouter(Location));
 

--- a/shared/api-client.js
+++ b/shared/api-client.js
@@ -125,6 +125,18 @@ function getCropRelationships(params) {
 }
 
 /**
+ * Get crop tags
+ *
+ * @param  {Object} params
+ * @param  {String[]} params.ids Document IDs
+ * @return {Promise}
+ */
+function getCropTags(params) {
+	let promises = params.ids.map(id => getCropTag({ id: id }));
+	return Promise.all(promises);
+}
+
+/**
  * Get users
  *
  * @param  {Object} params
@@ -157,6 +169,18 @@ function addCrops(params) {
  */
 function addCropRelationships(params) {
 	let promises = params.documents.map(document => addCropRelationship({ document: document }));
+	return Promise.all(promises);
+}
+
+/**
+ * Add crop tags
+ *
+ * @param  {Object} params
+ * @param  {Object[]} params.documents Documents
+ * @return {Promise}
+ */
+function addCropTags(params) {
+	let promises = params.documents.map(document => addCropTag({ document: document }));
 	return Promise.all(promises);
 }
 
@@ -198,6 +222,18 @@ function setCropRelationships(params) {
 }
 
 /**
+ * Update crop tags
+ *
+ * @param  {Object} params
+ * @param  {Object[]} params.documents Documents
+ * @return {Promise}
+ */
+function setCropTags(params) {
+	let promises = params.documents.map((document, index) => setCropTag({ document: document, id: params.ids[index] }));
+	return Promise.all(promises);
+}
+
+/**
  * Add users
  *
  * @param  {Object} params
@@ -230,6 +266,18 @@ function removeCrops(params) {
  */
 function removeCropRelationships(params) {
 	let promises = params.ids.map(id => removeCropRelationship({ id: id }));
+	return Promise.all(promises);
+}
+
+/**
+ * Delete crop tags
+ *
+ * @param  {Object} params
+ * @param  {String[]} params.ids Document IDs
+ * @return {Promise}
+ */
+function removeCropTags(params) {
+	let promises = params.ids.map(id => removeCropTag({ id: id }));
 	return Promise.all(promises);
 }
 
@@ -301,6 +349,17 @@ function getCropRelationship(params) {
 }
 
 /**
+ * Get crop tag
+ *
+ * @param  {Object} params
+ * @param  {Object} params.id
+ * @return {Promise}
+ */
+function getCropTag(params) {
+	return axios.get('/api/crop-tags/' + params.id);
+}
+
+/**
  * Get user
  *
  * @param  {Object} params
@@ -331,6 +390,17 @@ function addCrop(params) {
  */
 function addCropRelationship(params) {
 	return axios.post('/api/crop-relationships/', params.document);
+}
+
+/**
+ * Add crop tag
+ *
+ * @param  {Object} params
+ * @param  {Object} params.id Document
+ * @return {Promise}
+ */
+function addCropTag(params) {
+	return axios.post('/api/crop-tags/', params.document);
 }
 
 /**
@@ -369,6 +439,18 @@ function setCropRelationship(params) {
 }
 
 /**
+ * Update crop tag
+ *
+ * @param  {Object} params
+ * @param  {Object} params.id Document ID
+ * @param  {Object} params.document Document
+ * @return {Promise}
+ */
+function setCropTag(params) {
+	return axios.put('/api/crop-tags/' + params.id, params.document);
+}
+
+/**
  * Update user
  *
  * @param  {Object} params
@@ -403,6 +485,17 @@ function removeCropRelationship(params) {
 }
 
 /**
+ * Delete crop tag
+ *
+ * @param  {Object} params
+ * @param  {Object} params.id Document ID
+ * @return {Promise}
+ */
+function removeCropTag(params) {
+	return axios.delete('/api/crop-tags/' + params.id);
+}
+
+/**
  * Delete user
  *
  * @param  {Object} params
@@ -419,21 +512,26 @@ module.exports = {
 
 	addCrop,
 	addCropRelationship,
+	addCropTag,
 	getCropsByName,
 	getCropGroups,
 	getCompatibleCrops,
 	getLocations,
 	getCrops,
 	getCropRelationships,
+	getCropTags,
 	getUsers,
 	addCrops,
 	addCropRelationships,
+	addCropTags,
 	addUsers,
 	setCrops,
 	setCropRelationships,
+	setCropTags,
 	setUsers,
 	removeCrops,
 	removeCropRelationships,
+	removeCropTags,
 	removeUsers,
 	removeAllCrops,
 	removeAllCropRelationships,

--- a/shared/api-client.js
+++ b/shared/api-client.js
@@ -525,6 +525,7 @@ module.exports = {
 	addCropRelationships,
 	addCropTags,
 	addUsers,
+	setCrop,
 	setCrops,
 	setCropRelationships,
 	setCropTags,

--- a/shared/api-client.js
+++ b/shared/api-client.js
@@ -186,7 +186,7 @@ function setCrops(params) {
 }
 
 /**
- * Add crop relationships
+ * Update crop relationships
  *
  * @param  {Object} params
  * @param  {Object[]} params.documents Documents
@@ -353,7 +353,7 @@ function addUser(params) {
  * @return {Promise}
  */
 function setCrop(params) {
-	return axios.post('/api/crops/' + params.id, params.document);
+	return axios.put('/api/crops/' + params.id, params.document);
 }
 
 /**
@@ -365,7 +365,7 @@ function setCrop(params) {
  * @return {Promise}
  */
 function setCropRelationship(params) {
-	return axios.post('/api/crop-relationships/' + params.id, params.document);
+	return axios.put('/api/crop-relationships/' + params.id, params.document);
 }
 
 /**
@@ -377,7 +377,7 @@ function setCropRelationship(params) {
  * @return {Promise}
  */
 function setUser(params) {
-	return axios.post('/api/users/' + params.id, params.document);
+	return axios.put('/api/users/' + params.id, params.document);
 }
 
 /**


### PR DESCRIPTION
Makes it possible to group crops in the UI by adding tags to them. Rationale for this is to be able to later specify companions in the form _beans x carrot_ (see https://en.wikipedia.org/wiki/List_of_companion_plants for more examples).