### PR TITLE
Client<->server update mechanism

### DIFF
--- a/client/actions/cropActions.js
+++ b/client/actions/cropActions.js
@@ -3,29 +3,16 @@
  * @memberof client.actions
  */
 
-const { getCropsByName } = require('../../shared/api-client.js');
+const { getCropsByName, getUpdates } = require('../../shared/api-client.js');
 const {
 	cropsLoading,
 	cropsUpdated,
 	cropsLoadingError,
 	cropRelationshipsLoading,
 	cropRelationshipsUpdated,
-	cropRelationshipsLoadingError
+	cropRelationshipsLoadingError,
+	versionUpdated
 } = require('.');
-
-
-/**
- * decides if an update is needed
- * TODO: is still dumb and doesn't make decisions
- * @param  {number} lastUpdated millisec from the date of the last update
- * @return {boolean}             true if update is neccessary, false if not
- */
-const updateNeeded = (lastUpdated) => {
-	const now = new Date();
-	const updateInterval = 7 * 24 * 60 * 60 * 1000;
-	lastUpdated = 0; // HACK BEFORE INTELLIGENT UPDATE MECHANISM
-	return ( now.getTime() - lastUpdated) > updateInterval
-}
 
 /**
  * Fetches crops from server if not existent or old data
@@ -33,24 +20,20 @@ const updateNeeded = (lastUpdated) => {
  * @return {Function}		function for dispatch
  */
 const fetchCrops = () => {
-	const name = '';
-	const index = '';
-	const length = '';
-
-  	// some intelligent update mechanism should be here but
-	// instead we set an update interval
-	
 	return (dispatch, getState) => {
-		if (updateNeeded(getState().crops.relationshipsUpdated)) {
-			dispatch(cropsLoading(true));
-			return getCropsByName({ name, index, length }).then(res => {
-				dispatch(cropsUpdated(res.data));
+		dispatch(cropsLoading(true));
+		return getUpdates(getState().version)
+			.then(result => {
+				const updates = result.data;
+				if (updates.hasOwnProperty('crops')) {
+					dispatch(cropsUpdated(updates.crops.crops));
+					dispatch(versionUpdated({ crops: updates.crops.version }));
+				}
 				dispatch(cropsLoading(false));
 			}).catch(error => {
 				dispatch(cropsLoadingError(error));
 				dispatch(cropsLoading(false));
 			});
-		}
 	};
 };
 

--- a/client/actions/cropActions.js
+++ b/client/actions/cropActions.js
@@ -3,7 +3,7 @@
  * @memberof client.actions
  */
 
-const { getCropsByName, getAllCropRelationships } = require('../../shared/api-client.js');
+const { getCropsByName } = require('../../shared/api-client.js');
 const {
 	cropsLoading,
 	cropsUpdated,
@@ -54,27 +54,6 @@ const fetchCrops = () => {
 	};
 };
 
-/**
- * Fetches Relationship from server if not existent or old data
- * @return {function} function for dispatch
- */
-const fetchRelationships = () => {
-	return (dispatch, getState) => {
-		if (updateNeeded(getState().crops.companionships.updated)) {
-			dispatch(cropRelationshipsLoading(true));
-			return getAllCropRelationships().then(res => {
-				if (res.status === 200) {
-					dispatch(cropRelationshipsUpdated(res.data));
-				} else {
-					dispatch(cropRelationshipsLoadingError(res));
-				}
-				dispatch(cropRelationshipsLoading(false));
-			});
-		}
-	};
-};
-
 module.exports = {
-	fetchCrops,
-	fetchRelationships
+	fetchCrops
 };

--- a/client/actions/index.js
+++ b/client/actions/index.js
@@ -33,6 +33,8 @@ const CROP_RELATIONSHIPS_UPDATED = 'CROP_RELATIONSHIPS_UPDATED';
 const CROPS_LOADING_ERROR = 'CROPS_LOADING_ERROR';
 const CROP_RELATIONSHIPS_LOADING_ERROR = 'CROP_RELATIONSHIPS_LOADING_ERROR';
 
+const VERSION_UPDATED = 'VERSION_UPDATED';
+
 /**
  * Indicate that the persisted Redux store has been loaded.
  * 
@@ -258,6 +260,18 @@ const setCurrentUser = (user) => ({
 	user
 });
 
+/**
+ * Update version information.
+ *
+ * @function
+ * @param {Object} version
+ * @return {Object} Action object
+ */
+const versionUpdated = (version) => ({
+	type: VERSION_UPDATED,
+	version
+});
+
 module.exports = {
 	STORE_LOADED,
 	SET_HEADER_TITLE,
@@ -278,6 +292,7 @@ module.exports = {
 	CROP_RELATIONSHIPS_UPDATED,
 	CROPS_LOADING_ERROR,
 	CROP_RELATIONSHIPS_LOADING_ERROR,
+	VERSION_UPDATED,
 	storeLoaded,
 	setHeaderTitle,
 	setTitle,
@@ -295,5 +310,6 @@ module.exports = {
 	cropsUpdated,
 	cropRelationshipsUpdated,
 	cropsLoadingError,
-	cropRelationshipsLoadingError
+	cropRelationshipsLoadingError,
+	versionUpdated
 };

--- a/client/components/crops/ChooseCrops.js
+++ b/client/components/crops/ChooseCrops.js
@@ -8,8 +8,7 @@ require('react-bootstrap-typeahead/css/Typeahead.css');
 const React = require('react');
 const PropTypes = require('prop-types');
 const {
-	fetchCrops,
-	fetchCombinations
+	fetchCrops
 } = require('../../actions/cropActions');
 const { connect } = require('react-redux');
 
@@ -49,8 +48,7 @@ ChooseCrops.propTypes = {
 }
 
 const mapDispatchToProps = (dispatch) => ({
-	fetchCrops: () => dispatch(fetchCrops()),
-	fetchCombinations: () => dispatch(fetchCombinations())
+	fetchCrops: () => dispatch(fetchCrops())
 });
 
 const mapStateToProps = (state) => ({

--- a/client/reducers/index.js
+++ b/client/reducers/index.js
@@ -28,6 +28,7 @@ const { currLocation } = require('./currLocation');
 const { locations } = require('./locations');
 const { crops } = require('./crops');
 const { app } = require('./app');
+const { version } = require('./version');
 
 module.exports = combineReducers({
     title,
@@ -35,5 +36,6 @@ module.exports = combineReducers({
     currLocation,
     locations,
     crops,
-    app
+    app,
+    version
 });

--- a/client/reducers/version.js
+++ b/client/reducers/version.js
@@ -1,0 +1,24 @@
+/**
+ * @namespace version
+ * @memberof client.reducers
+ */
+
+const { VERSION_UPDATED } = require('../actions');
+
+const initialState = {
+  crops: 0
+};
+
+function version(state = initialState, action) {
+  switch (action.type) {
+    case VERSION_UPDATED:
+      console.log('VERSION_UPDATED');
+      return Object.assign({}, state, action.version);
+    default:
+      return state;
+  }
+}
+
+module.exports = {
+  version
+};

--- a/server/middleware.js
+++ b/server/middleware.js
@@ -401,6 +401,25 @@ async function getLocations(req, res, next) {
 }
 
 /**
+ * Check version information and get updates if necessary.
+ *
+ * @param {Object} req
+ * @param {Object} res
+ * @param {Function} next
+ */
+async function getUpdates(req, res, next) {
+	try {
+		const session = await startSessionAndTransaction(null);
+		const updates = await processor.getUpdates(session, req.body);
+		await endSessionAndTransaction(session);
+		
+		res.json(updates);
+	} catch (exception) {
+		handleError(next, exception);
+	}
+}
+
+/**
  * Login with username and password, and respond with
  * authorization token.
  * 
@@ -429,5 +448,6 @@ module.exports = {
 	getCropGroups,
 	getCompatibleCrops,
 	getLocations,
+	getUpdates,
 	login
 };

--- a/server/models/version.js
+++ b/server/models/version.js
@@ -1,0 +1,16 @@
+const mongoose = require('mongoose');
+
+/**
+ * This collection contains version information for the current state of the
+ * database, and it is used to determine when to send updates to clients.
+ */
+const versionSchema = new mongoose.Schema({
+  crops: {
+    type: Number,
+    required: true
+  }
+});
+
+const Version = mongoose.model('Version', versionSchema);
+
+module.exports = Version;

--- a/server/server.js
+++ b/server/server.js
@@ -19,6 +19,7 @@ const {
 	getAllCropRelationships,
 	getCropsByName,
 	getLocations,
+	getUpdates,
 	login
 } = require('./middleware');
 const Crop = require('./models/crop');
@@ -97,6 +98,7 @@ function buildApiRouter() {
 	router.post('/get-compatible-crops', getCompatibleCrops);
 	router.get('/get-all-crop-relationships', getAllCropRelationships);
 	router.get('/get-locations', getLocations);
+	router.post('/get-updates', getUpdates);
 
 	router.get('*', (req, res, next) => {
 		next({ status: 404, message: 'No such route' });

--- a/server/server.js
+++ b/server/server.js
@@ -27,15 +27,9 @@ const CropTag = require('./models/crop-tag');
 const Location = require('./models/location');
 const User = require('./models/user');
 const {
-	DATABASE_USERNAME,
-	DATABASE_PASSWORD,
-	DATABASE_PROTOCOLL,
-	DATABASE_HOST,
-	DATABASE_PORT,
-	DATABASE_DB,
 	PP_PORT
 } = require('../secrets.js');
-const { isDevelopmentMode } = require('./utils');
+const { getDatabaseURL, isDevelopmentMode } = require('./utils');
 
 /**
  * Build router for a document API.
@@ -176,23 +170,6 @@ function buildApp(development) {
 	});
 
 	return app;
-}
-
-/**
- * @return {String}
- */
-const getDatabaseURL = () => {
-	let urlString = DATABASE_PROTOCOLL;
-	// Add username and password
-	if (DATABASE_USERNAME.length > 0 && DATABASE_PASSWORD.length > 0) {
-		urlString += DATABASE_USERNAME + ':' + DATABASE_PASSWORD + '@';
-	}
-	urlString += DATABASE_HOST;
-	if (DATABASE_PORT.length > 0) {
-		urlString += ':' + DATABASE_PORT;
-	}
-	urlString += '/' + DATABASE_DB;
-	return urlString;
 }
 
 /**

--- a/server/utils.js
+++ b/server/utils.js
@@ -5,6 +5,32 @@
  * @memberof server
  */
 
+const {
+	DATABASE_USERNAME,
+	DATABASE_PASSWORD,
+	DATABASE_PROTOCOLL,
+	DATABASE_HOST,
+	DATABASE_PORT,
+	DATABASE_DB
+} = require('../secrets.js');
+
+/**
+ * @return {String}
+ */
+function getDatabaseURL() {
+	let urlString = DATABASE_PROTOCOLL;
+	// Add username and password
+	if (DATABASE_USERNAME.length > 0 && DATABASE_PASSWORD.length > 0) {
+		urlString += DATABASE_USERNAME + ':' + DATABASE_PASSWORD + '@';
+	}
+	urlString += DATABASE_HOST;
+	if (DATABASE_PORT.length > 0) {
+		urlString += ':' + DATABASE_PORT;
+	}
+	urlString += '/' + DATABASE_DB;
+	return urlString;
+}
+
 /**
  * Check if development mode is on.
  * 
@@ -26,6 +52,7 @@ function debug(message) {
 }
 
 module.exports = {
+	getDatabaseURL,
 	isDevelopmentMode,
 	debug
 };

--- a/shared/api-client.js
+++ b/shared/api-client.js
@@ -101,6 +101,14 @@ function getLocations(params) {
 }
 
 /**
+ * @param {Object} params
+ * @return {Promise}
+ */
+function getUpdates(params) {
+	return axios.post('/api/get-updates', params);
+}
+
+/**
  * Get crops
  *
  * @param  {Object} params
@@ -517,6 +525,7 @@ module.exports = {
 	getCropGroups,
 	getCompatibleCrops,
 	getLocations,
+	getUpdates,
 	getCrops,
 	getCropRelationships,
 	getCropTags,


### PR DESCRIPTION
Server keeps track of the version information in a separate collection. The targets of versioning may be arbitrary sets of data, not necessarily single documents or single collections. Currently there is only one target: the whole crops collection.

Client calls `/api/get-updates` to query updates against their current data: if the client's version doesn't match the server's version the server returns the corresponding updates to the client.